### PR TITLE
Added git to the image to allow git connections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ ENV CRUCIBLE_INSTALL	/opt/atlassian/${SOFT}
 ENV SOFT_HOME		${CRUCIBLE_HOME}
 ENV SOFT_INSTALL	${CRUCIBLE_INSTALL}
 ENV SOFT_VERSION	${CRUCIBLE_VERSION}
-
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
 # download option
 RUN apk add --no-cache curl bash && \
 	curl -s https://raw.githubusercontent.com/babim/docker-tag-options/master/z%20SCRIPT%20AUTO/option.sh -o /option.sh && \


### PR DESCRIPTION
Hey. Was creating a helm chart using your docker image but crucible could not connect to git so I had to add git as well. Though I could do a pr as well. Thanks for the image btw.